### PR TITLE
Use generic EmbeddingStore and EmbeddingModel

### DIFF
--- a/docs/docs/step-06.md
+++ b/docs/docs/step-06.md
@@ -63,7 +63,11 @@ Thus, you do not have to send your document to a remote service to compute the e
 This embedding model generates vectors of size 384.
 It's a small model, but it's enough for our use case.
 
-To use the model, we will use the [`dev.langchain4j.model.embedding.onnx.bgesmallenq.BgeSmallEnQuantizedEmbeddingModel`](https://github.com/langchain4j/langchain4j-embeddings/blob/main/langchain4j-embeddings-bge-small-en-q/src/main/java/dev/langchain4j/model/embedding/onnx/bgesmallenq/BgeSmallEnQuantizedEmbeddingModel.java){target="_blank"} CDI bean automatically created by Quarkus.
+To use the model, we will use the [`dev.langchain4j.model.embedding.onnx.bgesmallenq.BgeSmallEnQuantizedEmbeddingModel`](https://github.com/langchain4j/langchain4j-embeddings/blob/main/langchain4j-embeddings-bge-small-en-q/src/main/java/dev/langchain4j/model/embedding/onnx/bgesmallenq/BgeSmallEnQuantizedEmbeddingModel.java){target="_blank"} CDI bean automatically created by Quarkus by adding the following to `src/main/resources/application.properties`:
+
+```properties title="application.properties"
+--8<-- "../../step-06/src/main/resources/application.properties:embedding-model"
+```
 
 ## Vector store
 

--- a/step-06/src/main/java/dev/langchain4j/quarkus/workshop/RagIngestion.java
+++ b/step-06/src/main/java/dev/langchain4j/quarkus/workshop/RagIngestion.java
@@ -1,20 +1,23 @@
 package dev.langchain4j.quarkus.workshop;
 
-import dev.langchain4j.data.document.Document;
-import dev.langchain4j.data.document.loader.FileSystemDocumentLoader;
-import dev.langchain4j.model.embedding.onnx.bgesmallenq.BgeSmallEnQuantizedEmbeddingModel;
-import dev.langchain4j.store.embedding.EmbeddingStoreIngestor;
-import io.quarkiverse.langchain4j.pgvector.PgVectorEmbeddingStore;
-import io.quarkus.logging.Log;
-import io.quarkus.runtime.StartupEvent;
-import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.enterprise.event.Observes;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
+import static dev.langchain4j.data.document.splitter.DocumentSplitters.recursive;
 
 import java.nio.file.Path;
 import java.util.List;
 
-import static dev.langchain4j.data.document.splitter.DocumentSplitters.recursive;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import io.quarkus.logging.Log;
+import io.quarkus.runtime.StartupEvent;
+
+import dev.langchain4j.data.document.Document;
+import dev.langchain4j.data.document.loader.FileSystemDocumentLoader;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import dev.langchain4j.store.embedding.EmbeddingStoreIngestor;
 
 @ApplicationScoped
 public class RagIngestion {
@@ -28,7 +31,7 @@ public class RagIngestion {
      * @param documents      the location of the documents to ingest
      */
     public void ingest(@Observes StartupEvent ev,
-                       PgVectorEmbeddingStore store, BgeSmallEnQuantizedEmbeddingModel embeddingModel,
+                       EmbeddingStore store, EmbeddingModel embeddingModel,
                        @ConfigProperty(name = "rag.location") Path documents) {
         store.removeAll(); // cleanup the store to start fresh (just for demo purposes)
         List<Document> list = FileSystemDocumentLoader.loadDocumentsRecursively(documents);

--- a/step-06/src/main/java/dev/langchain4j/quarkus/workshop/RagRetriever.java
+++ b/step-06/src/main/java/dev/langchain4j/quarkus/workshop/RagRetriever.java
@@ -7,19 +7,19 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Produces;
 
 import dev.langchain4j.data.message.UserMessage;
-import dev.langchain4j.model.embedding.onnx.bgesmallenq.BgeSmallEnQuantizedEmbeddingModel;
+import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.rag.DefaultRetrievalAugmentor;
 import dev.langchain4j.rag.RetrievalAugmentor;
 import dev.langchain4j.rag.content.Content;
 import dev.langchain4j.rag.content.injector.ContentInjector;
 import dev.langchain4j.rag.content.retriever.EmbeddingStoreContentRetriever;
-import io.quarkiverse.langchain4j.pgvector.PgVectorEmbeddingStore;
+import dev.langchain4j.store.embedding.EmbeddingStore;
 
 public class RagRetriever {
 
     @Produces
     @ApplicationScoped
-    public RetrievalAugmentor create(PgVectorEmbeddingStore store, BgeSmallEnQuantizedEmbeddingModel model) {
+    public RetrievalAugmentor create(EmbeddingStore store, EmbeddingModel model) {
         var contentRetriever = EmbeddingStoreContentRetriever.builder()
                 .embeddingModel(model)
                 .embeddingStore(store)

--- a/step-06/src/main/resources/application.properties
+++ b/step-06/src/main/resources/application.properties
@@ -16,3 +16,6 @@ quarkus.langchain4j.pgvector.dimension=384
 rag.location=src/main/resources/rag
 #--8<-- [end:rag]
 
+#--8<-- [start:embedding-model]
+quarkus.langchain4j.embedding-model.provider=dev.langchain4j.model.embedding.onnx.bgesmallenq.BgeSmallEnQuantizedEmbeddingModel
+#--8<-- [end:embedding-model]

--- a/step-07/src/main/java/dev/langchain4j/quarkus/workshop/RagIngestion.java
+++ b/step-07/src/main/java/dev/langchain4j/quarkus/workshop/RagIngestion.java
@@ -1,20 +1,23 @@
 package dev.langchain4j.quarkus.workshop;
 
-import dev.langchain4j.data.document.Document;
-import dev.langchain4j.data.document.loader.FileSystemDocumentLoader;
-import dev.langchain4j.model.embedding.onnx.bgesmallenq.BgeSmallEnQuantizedEmbeddingModel;
-import dev.langchain4j.store.embedding.EmbeddingStoreIngestor;
-import io.quarkiverse.langchain4j.pgvector.PgVectorEmbeddingStore;
-import io.quarkus.logging.Log;
-import io.quarkus.runtime.StartupEvent;
-import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.enterprise.event.Observes;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
+import static dev.langchain4j.data.document.splitter.DocumentSplitters.recursive;
 
 import java.nio.file.Path;
 import java.util.List;
 
-import static dev.langchain4j.data.document.splitter.DocumentSplitters.recursive;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import io.quarkus.logging.Log;
+import io.quarkus.runtime.StartupEvent;
+
+import dev.langchain4j.data.document.Document;
+import dev.langchain4j.data.document.loader.FileSystemDocumentLoader;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import dev.langchain4j.store.embedding.EmbeddingStoreIngestor;
 
 @ApplicationScoped
 public class RagIngestion {
@@ -28,7 +31,7 @@ public class RagIngestion {
      * @param documents      the location of the documents to ingest
      */
     public void ingest(@Observes StartupEvent ev,
-                       PgVectorEmbeddingStore store, BgeSmallEnQuantizedEmbeddingModel embeddingModel,
+                       EmbeddingStore store, EmbeddingModel embeddingModel,
                        @ConfigProperty(name = "rag.location") Path documents) {
         store.removeAll(); // cleanup the store to start fresh (just for demo purposes)
         List<Document> list = FileSystemDocumentLoader.loadDocumentsRecursively(documents);

--- a/step-07/src/main/java/dev/langchain4j/quarkus/workshop/RagRetriever.java
+++ b/step-07/src/main/java/dev/langchain4j/quarkus/workshop/RagRetriever.java
@@ -1,24 +1,25 @@
 package dev.langchain4j.quarkus.workshop;
 
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+
 import dev.langchain4j.data.message.UserMessage;
-import dev.langchain4j.model.embedding.onnx.bgesmallenq.BgeSmallEnQuantizedEmbeddingModel;
+import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.rag.DefaultRetrievalAugmentor;
 import dev.langchain4j.rag.RetrievalAugmentor;
 import dev.langchain4j.rag.content.Content;
 import dev.langchain4j.rag.content.injector.ContentInjector;
 import dev.langchain4j.rag.content.retriever.EmbeddingStoreContentRetriever;
-import io.quarkiverse.langchain4j.pgvector.PgVectorEmbeddingStore;
-import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.enterprise.inject.Produces;
-
-import java.util.List;
+import dev.langchain4j.store.embedding.EmbeddingStore;
 
 public class RagRetriever {
 
     @Produces
     @ApplicationScoped
-    public RetrievalAugmentor create(PgVectorEmbeddingStore store, BgeSmallEnQuantizedEmbeddingModel model) {
-        EmbeddingStoreContentRetriever contentRetriever = EmbeddingStoreContentRetriever.builder()
+    public RetrievalAugmentor create(EmbeddingStore store, EmbeddingModel model) {
+        var contentRetriever = EmbeddingStoreContentRetriever.builder()
                 .embeddingModel(model)
                 .embeddingStore(store)
                 .maxResults(3)

--- a/step-07/src/main/resources/application.properties
+++ b/step-07/src/main/resources/application.properties
@@ -7,4 +7,4 @@ quarkus.langchain4j.openai.chat-model.max-tokens=1000
 quarkus.langchain4j.openai.chat-model.frequency-penalty=0
 quarkus.langchain4j.pgvector.dimension=384
 rag.location=src/main/resources/rag
-
+quarkus.langchain4j.embedding-model.provider=dev.langchain4j.model.embedding.onnx.bgesmallenq.BgeSmallEnQuantizedEmbeddingModel

--- a/step-08/src/main/java/dev/langchain4j/quarkus/workshop/RagIngestion.java
+++ b/step-08/src/main/java/dev/langchain4j/quarkus/workshop/RagIngestion.java
@@ -1,20 +1,23 @@
 package dev.langchain4j.quarkus.workshop;
 
-import dev.langchain4j.data.document.Document;
-import dev.langchain4j.data.document.loader.FileSystemDocumentLoader;
-import dev.langchain4j.model.embedding.onnx.bgesmallenq.BgeSmallEnQuantizedEmbeddingModel;
-import dev.langchain4j.store.embedding.EmbeddingStoreIngestor;
-import io.quarkiverse.langchain4j.pgvector.PgVectorEmbeddingStore;
-import io.quarkus.logging.Log;
-import io.quarkus.runtime.StartupEvent;
-import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.enterprise.event.Observes;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
+import static dev.langchain4j.data.document.splitter.DocumentSplitters.recursive;
 
 import java.nio.file.Path;
 import java.util.List;
 
-import static dev.langchain4j.data.document.splitter.DocumentSplitters.recursive;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import io.quarkus.logging.Log;
+import io.quarkus.runtime.StartupEvent;
+
+import dev.langchain4j.data.document.Document;
+import dev.langchain4j.data.document.loader.FileSystemDocumentLoader;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import dev.langchain4j.store.embedding.EmbeddingStoreIngestor;
 
 @ApplicationScoped
 public class RagIngestion {
@@ -28,7 +31,7 @@ public class RagIngestion {
      * @param documents      the location of the documents to ingest
      */
     public void ingest(@Observes StartupEvent ev,
-                       PgVectorEmbeddingStore store, BgeSmallEnQuantizedEmbeddingModel embeddingModel,
+                       EmbeddingStore store, EmbeddingModel embeddingModel,
                        @ConfigProperty(name = "rag.location") Path documents) {
         store.removeAll(); // cleanup the store to start fresh (just for demo purposes)
         List<Document> list = FileSystemDocumentLoader.loadDocumentsRecursively(documents);

--- a/step-08/src/main/java/dev/langchain4j/quarkus/workshop/RagRetriever.java
+++ b/step-08/src/main/java/dev/langchain4j/quarkus/workshop/RagRetriever.java
@@ -1,24 +1,25 @@
 package dev.langchain4j.quarkus.workshop;
 
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+
 import dev.langchain4j.data.message.UserMessage;
-import dev.langchain4j.model.embedding.onnx.bgesmallenq.BgeSmallEnQuantizedEmbeddingModel;
+import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.rag.DefaultRetrievalAugmentor;
 import dev.langchain4j.rag.RetrievalAugmentor;
 import dev.langchain4j.rag.content.Content;
 import dev.langchain4j.rag.content.injector.ContentInjector;
 import dev.langchain4j.rag.content.retriever.EmbeddingStoreContentRetriever;
-import io.quarkiverse.langchain4j.pgvector.PgVectorEmbeddingStore;
-import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.enterprise.inject.Produces;
-
-import java.util.List;
+import dev.langchain4j.store.embedding.EmbeddingStore;
 
 public class RagRetriever {
 
     @Produces
     @ApplicationScoped
-    public RetrievalAugmentor create(PgVectorEmbeddingStore store, BgeSmallEnQuantizedEmbeddingModel model) {
-        EmbeddingStoreContentRetriever contentRetriever = EmbeddingStoreContentRetriever.builder()
+    public RetrievalAugmentor create(EmbeddingStore store, EmbeddingModel model) {
+        var contentRetriever = EmbeddingStoreContentRetriever.builder()
                 .embeddingModel(model)
                 .embeddingStore(store)
                 .maxResults(3)

--- a/step-08/src/main/resources/application.properties
+++ b/step-08/src/main/resources/application.properties
@@ -7,4 +7,4 @@ quarkus.langchain4j.openai.chat-model.max-tokens=1000
 quarkus.langchain4j.openai.chat-model.frequency-penalty=0
 quarkus.langchain4j.pgvector.dimension=384
 rag.location=src/main/resources/rag
-
+quarkus.langchain4j.embedding-model.provider=dev.langchain4j.model.embedding.onnx.bgesmallenq.BgeSmallEnQuantizedEmbeddingModel


### PR DESCRIPTION
Use generic `EmbeddingStore` and `EmbeddingModel` classes in method signatures rather than specific implementations.