### PR TITLE
Add profile to use ollama + bump quarkus and langchain4j versions

### DIFF
--- a/docs/docs/step-07.md
+++ b/docs/docs/step-07.md
@@ -1,4 +1,4 @@
-# Step 06 - Function calling and Tools
+# Step 07 - Function calling and Tools
 
 The RAG pattern allows passing knowledge to the LLM based on your own data.
 It's a very popular pattern, but not the only one that can be used.
@@ -22,7 +22,7 @@ The result is sent back to the LLM, which can use it to continue the conversatio
 In this step, we are going to see how to implement function calling in our application.
 We will set up a database and create a function that allows the LLM to retrieve data (bookings, customers...) from the database.
 
-The final code is available in the `step-06` folder.
+The final code is available in the `step-07` folder.
 However, we recommend you follow the step-by-step guide to understand how it works, and the different steps to implement this pattern.
 
 ## A couple of new dependencies

--- a/step-01/pom.xml
+++ b/step-01/pom.xml
@@ -16,8 +16,8 @@
 
         <compiler-plugin.version>3.13.0</compiler-plugin.version>
 
-        <quarkus.platform.version>3.15.1</quarkus.platform.version>
-        <quarkus-langchain4j.version>0.18.0</quarkus-langchain4j.version>
+        <quarkus.platform.version>3.17.5</quarkus.platform.version>
+        <quarkus-langchain4j.version>0.22.0</quarkus-langchain4j.version>
     </properties>
 
     <dependencyManagement>
@@ -33,12 +33,6 @@
     </dependencyManagement>
 
     <dependencies>
-
-        <dependency>
-            <groupId>io.quarkiverse.langchain4j</groupId>
-            <artifactId>quarkus-langchain4j-openai</artifactId>
-            <version>${quarkus-langchain4j.version}</version>
-        </dependency>
 
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -106,4 +100,38 @@
 
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>openai</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+                <property>
+                    <name>openai</name>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>io.quarkiverse.langchain4j</groupId>
+                    <artifactId>quarkus-langchain4j-openai</artifactId>
+                    <version>${quarkus-langchain4j.version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>ollama</id>
+            <activation>
+                <property>
+                    <name>ollama</name>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>io.quarkiverse.langchain4j</groupId>
+                    <artifactId>quarkus-langchain4j-ollama</artifactId>
+                    <version>${quarkus-langchain4j.version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>

--- a/step-01/src/main/resources/application.properties
+++ b/step-01/src/main/resources/application.properties
@@ -1,5 +1,10 @@
-quarkus.langchain4j.openai.api-key=${OPENAI_API_KEY}
+quarkus.langchain4j.log-requests=true
+quarkus.langchain4j.log-responses=true
 
+# OpenAI
+quarkus.langchain4j.openai.api-key=${OPENAI_API_KEY}
 quarkus.langchain4j.openai.chat-model.model-name=gpt-4o
-quarkus.langchain4j.openai.chat-model.log-requests=true
-quarkus.langchain4j.openai.chat-model.log-responses=true
+
+# Ollama
+quarkus.langchain4j.ollama.chat-model.model-id=llama3.2
+quarkus.langchain4j.ollama.timeout=180s

--- a/step-02/pom.xml
+++ b/step-02/pom.xml
@@ -17,8 +17,8 @@
 
         <compiler-plugin.version>3.13.0</compiler-plugin.version>
 
-        <quarkus.platform.version>3.15.1</quarkus.platform.version>
-        <quarkus-langchain4j.version>0.18.0</quarkus-langchain4j.version>
+        <quarkus.platform.version>3.17.5</quarkus.platform.version>
+        <quarkus-langchain4j.version>0.22.0</quarkus-langchain4j.version>
     </properties>
 
     <dependencyManagement>
@@ -34,12 +34,6 @@
     </dependencyManagement>
 
     <dependencies>
-
-        <dependency>
-            <groupId>io.quarkiverse.langchain4j</groupId>
-            <artifactId>quarkus-langchain4j-openai</artifactId>
-            <version>${quarkus-langchain4j.version}</version>
-        </dependency>
 
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -109,4 +103,38 @@
 
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>openai</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+                <property>
+                    <name>openai</name>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>io.quarkiverse.langchain4j</groupId>
+                    <artifactId>quarkus-langchain4j-openai</artifactId>
+                    <version>${quarkus-langchain4j.version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>ollama</id>
+            <activation>
+                <property>
+                    <name>ollama</name>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>io.quarkiverse.langchain4j</groupId>
+                    <artifactId>quarkus-langchain4j-ollama</artifactId>
+                    <version>${quarkus-langchain4j.version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>

--- a/step-02/src/main/resources/application.properties
+++ b/step-02/src/main/resources/application.properties
@@ -1,9 +1,15 @@
-quarkus.langchain4j.openai.api-key=${OPENAI_API_KEY}
+quarkus.langchain4j.log-requests=true
+quarkus.langchain4j.log-responses=true
 
+# OpenAI
+quarkus.langchain4j.openai.api-key=${OPENAI_API_KEY}
 quarkus.langchain4j.openai.chat-model.model-name=gpt-4o
-quarkus.langchain4j.openai.chat-model.log-requests=true
-quarkus.langchain4j.openai.chat-model.log-responses=true
 
 quarkus.langchain4j.openai.chat-model.temperature=1.0
 quarkus.langchain4j.openai.chat-model.max-tokens=1000
 quarkus.langchain4j.openai.chat-model.frequency-penalty=0
+
+# Ollama
+quarkus.langchain4j.ollama.chat-model.model-id=llama3.2
+quarkus.langchain4j.ollama.timeout=180s
+quarkus.langchain4j.ollama.chat-model.temperature=1.0

--- a/step-03/pom.xml
+++ b/step-03/pom.xml
@@ -16,8 +16,8 @@
 
         <compiler-plugin.version>3.13.0</compiler-plugin.version>
 
-        <quarkus.platform.version>3.15.1</quarkus.platform.version>
-        <quarkus-langchain4j.version>0.18.0</quarkus-langchain4j.version>
+        <quarkus.platform.version>3.17.5</quarkus.platform.version>
+        <quarkus-langchain4j.version>0.22.0</quarkus-langchain4j.version>
     </properties>
 
     <dependencyManagement>
@@ -33,12 +33,6 @@
     </dependencyManagement>
 
     <dependencies>
-
-        <dependency>
-            <groupId>io.quarkiverse.langchain4j</groupId>
-            <artifactId>quarkus-langchain4j-openai</artifactId>
-            <version>${quarkus-langchain4j.version}</version>
-        </dependency>
 
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -104,7 +98,40 @@
                     </execution>
                 </executions>
             </plugin>
-
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>openai</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+                <property>
+                    <name>openai</name>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>io.quarkiverse.langchain4j</groupId>
+                    <artifactId>quarkus-langchain4j-openai</artifactId>
+                    <version>${quarkus-langchain4j.version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>ollama</id>
+            <activation>
+                <property>
+                    <name>ollama</name>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>io.quarkiverse.langchain4j</groupId>
+                    <artifactId>quarkus-langchain4j-ollama</artifactId>
+                    <version>${quarkus-langchain4j.version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>

--- a/step-03/src/main/resources/application.properties
+++ b/step-03/src/main/resources/application.properties
@@ -1,11 +1,15 @@
-quarkus.langchain4j.openai.api-key=${OPENAI_API_KEY}
+quarkus.langchain4j.log-requests=true
+quarkus.langchain4j.log-responses=true
 
+# OpenAI
+quarkus.langchain4j.openai.api-key=${OPENAI_API_KEY}
 quarkus.langchain4j.openai.chat-model.model-name=gpt-4o
-quarkus.langchain4j.openai.chat-model.log-requests=true
-quarkus.langchain4j.openai.chat-model.log-responses=true
 
 quarkus.langchain4j.openai.chat-model.temperature=1.0
 quarkus.langchain4j.openai.chat-model.max-tokens=1000
 quarkus.langchain4j.openai.chat-model.frequency-penalty=0
 
-
+# Ollama
+quarkus.langchain4j.ollama.chat-model.model-id=llama3.2
+quarkus.langchain4j.ollama.timeout=180s
+quarkus.langchain4j.ollama.chat-model.temperature=1.0

--- a/step-04/pom.xml
+++ b/step-04/pom.xml
@@ -16,8 +16,8 @@
 
         <compiler-plugin.version>3.13.0</compiler-plugin.version>
 
-        <quarkus.platform.version>3.15.1</quarkus.platform.version>
-        <quarkus-langchain4j.version>0.18.0</quarkus-langchain4j.version>
+        <quarkus.platform.version>3.17.5</quarkus.platform.version>
+        <quarkus-langchain4j.version>0.22.0</quarkus-langchain4j.version>
     </properties>
 
     <dependencyManagement>
@@ -33,12 +33,6 @@
     </dependencyManagement>
 
     <dependencies>
-
-        <dependency>
-            <groupId>io.quarkiverse.langchain4j</groupId>
-            <artifactId>quarkus-langchain4j-openai</artifactId>
-            <version>${quarkus-langchain4j.version}</version>
-        </dependency>
 
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -107,4 +101,38 @@
 
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>openai</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+                <property>
+                    <name>openai</name>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>io.quarkiverse.langchain4j</groupId>
+                    <artifactId>quarkus-langchain4j-openai</artifactId>
+                    <version>${quarkus-langchain4j.version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>ollama</id>
+            <activation>
+                <property>
+                    <name>ollama</name>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>io.quarkiverse.langchain4j</groupId>
+                    <artifactId>quarkus-langchain4j-ollama</artifactId>
+                    <version>${quarkus-langchain4j.version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>

--- a/step-04/src/main/resources/application.properties
+++ b/step-04/src/main/resources/application.properties
@@ -1,9 +1,15 @@
-quarkus.langchain4j.openai.api-key=${OPENAI_API_KEY}
+quarkus.langchain4j.log-requests=true
+quarkus.langchain4j.log-responses=true
 
+# OpenAI
+quarkus.langchain4j.openai.api-key=${OPENAI_API_KEY}
 quarkus.langchain4j.openai.chat-model.model-name=gpt-4o
-quarkus.langchain4j.openai.chat-model.log-requests=true
-quarkus.langchain4j.openai.chat-model.log-responses=true
 
 quarkus.langchain4j.openai.chat-model.temperature=1.0
 quarkus.langchain4j.openai.chat-model.max-tokens=1000
 quarkus.langchain4j.openai.chat-model.frequency-penalty=0
+
+# Ollama
+quarkus.langchain4j.ollama.chat-model.model-id=llama3.2
+quarkus.langchain4j.ollama.timeout=180s
+quarkus.langchain4j.ollama.chat-model.temperature=1.0

--- a/step-05/pom.xml
+++ b/step-05/pom.xml
@@ -16,8 +16,8 @@
 
         <compiler-plugin.version>3.13.0</compiler-plugin.version>
 
-        <quarkus.platform.version>3.15.1</quarkus.platform.version>
-        <quarkus-langchain4j.version>0.18.0</quarkus-langchain4j.version>
+        <quarkus.platform.version>3.17.5</quarkus.platform.version>
+        <quarkus-langchain4j.version>0.22.0</quarkus-langchain4j.version>
     </properties>
 
     <dependencyManagement>
@@ -33,12 +33,6 @@
     </dependencyManagement>
 
     <dependencies>
-
-        <dependency>
-            <groupId>io.quarkiverse.langchain4j</groupId>
-            <artifactId>quarkus-langchain4j-openai</artifactId>
-            <version>${quarkus-langchain4j.version}</version>
-        </dependency>
 
         <!-- -8<- [start:easy-rag]       -->
         <dependency>
@@ -115,4 +109,38 @@
 
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>openai</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+                <property>
+                    <name>openai</name>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>io.quarkiverse.langchain4j</groupId>
+                    <artifactId>quarkus-langchain4j-openai</artifactId>
+                    <version>${quarkus-langchain4j.version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>ollama</id>
+            <activation>
+                <property>
+                    <name>ollama</name>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>io.quarkiverse.langchain4j</groupId>
+                    <artifactId>quarkus-langchain4j-ollama</artifactId>
+                    <version>${quarkus-langchain4j.version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>

--- a/step-05/src/main/resources/application.properties
+++ b/step-05/src/main/resources/application.properties
@@ -1,12 +1,18 @@
-quarkus.langchain4j.openai.api-key=${OPENAI_API_KEY}
+quarkus.langchain4j.log-requests=true
+quarkus.langchain4j.log-responses=true
 
+# OpenAI
+quarkus.langchain4j.openai.api-key=${OPENAI_API_KEY}
 quarkus.langchain4j.openai.chat-model.model-name=gpt-4o
-quarkus.langchain4j.openai.chat-model.log-requests=true
-quarkus.langchain4j.openai.chat-model.log-responses=true
 
 quarkus.langchain4j.openai.chat-model.temperature=1.0
 quarkus.langchain4j.openai.chat-model.max-tokens=1000
 quarkus.langchain4j.openai.chat-model.frequency-penalty=0
+
+# Ollama
+quarkus.langchain4j.ollama.chat-model.model-id=llama3.2
+quarkus.langchain4j.ollama.timeout=180s
+quarkus.langchain4j.ollama.chat-model.temperature=1.0
 
 #--8<-- [start:easy-rag]
 quarkus.langchain4j.easy-rag.path=src/main/resources/rag

--- a/step-06/pom.xml
+++ b/step-06/pom.xml
@@ -16,8 +16,9 @@
 
         <compiler-plugin.version>3.13.0</compiler-plugin.version>
 
-        <quarkus.platform.version>3.15.1</quarkus.platform.version>
-        <quarkus-langchain4j.version>0.18.0</quarkus-langchain4j.version>
+        <quarkus.platform.version>3.17.5</quarkus.platform.version>
+        <quarkus-langchain4j.version>0.22.0</quarkus-langchain4j.version>
+        <langchain4j.version>0.36.2</langchain4j.version>
     </properties>
 
     <dependencyManagement>
@@ -34,17 +35,11 @@
 
     <dependencies>
 
-        <dependency>
-            <groupId>io.quarkiverse.langchain4j</groupId>
-            <artifactId>quarkus-langchain4j-openai</artifactId>
-            <version>${quarkus-langchain4j.version}</version>
-        </dependency>
-
         <!-- -8<- [start:embedding-bge]       -->
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-embeddings-bge-small-en-q</artifactId>
-            <version>0.35.0</version>
+            <version>${langchain4j.version}</version>
         </dependency>
         <!-- -8<- [end:embedding-bge]       -->
         <!-- -8<- [start:pgvector]       -->
@@ -122,4 +117,38 @@
 
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>openai</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+                <property>
+                    <name>openai</name>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>io.quarkiverse.langchain4j</groupId>
+                    <artifactId>quarkus-langchain4j-openai</artifactId>
+                    <version>${quarkus-langchain4j.version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>ollama</id>
+            <activation>
+                <property>
+                    <name>ollama</name>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>io.quarkiverse.langchain4j</groupId>
+                    <artifactId>quarkus-langchain4j-ollama</artifactId>
+                    <version>${quarkus-langchain4j.version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>

--- a/step-06/src/main/java/dev/langchain4j/quarkus/workshop/RagRetriever.java
+++ b/step-06/src/main/java/dev/langchain4j/quarkus/workshop/RagRetriever.java
@@ -33,7 +33,7 @@ public class RagRetriever {
                 .contentInjector(new ContentInjector() {
                     @Override
                     public UserMessage inject(List<Content> list, UserMessage userMessage) {
-                        StringBuffer prompt = new StringBuffer(userMessage.singleText());
+                        StringBuilder prompt = new StringBuilder(userMessage.singleText());
                         prompt.append("\nPlease, only use the following information:\n");
                         list.forEach(content -> prompt.append("- ").append(content.textSegment().text()).append("\n"));
                         return new UserMessage(prompt.toString());

--- a/step-06/src/main/resources/application.properties
+++ b/step-06/src/main/resources/application.properties
@@ -1,12 +1,18 @@
-quarkus.langchain4j.openai.api-key=${OPENAI_API_KEY}
+quarkus.langchain4j.log-requests=true
+quarkus.langchain4j.log-responses=true
 
+# OpenAI
+quarkus.langchain4j.openai.api-key=${OPENAI_API_KEY}
 quarkus.langchain4j.openai.chat-model.model-name=gpt-4o
-quarkus.langchain4j.openai.chat-model.log-requests=true
-quarkus.langchain4j.openai.chat-model.log-responses=true
 
 quarkus.langchain4j.openai.chat-model.temperature=1.0
 quarkus.langchain4j.openai.chat-model.max-tokens=1000
 quarkus.langchain4j.openai.chat-model.frequency-penalty=0
+
+# Ollama
+quarkus.langchain4j.ollama.chat-model.model-id=llama3.2
+quarkus.langchain4j.ollama.timeout=180s
+quarkus.langchain4j.ollama.chat-model.temperature=1.0
 
 #--8<-- [start:pgvector]
 quarkus.langchain4j.pgvector.dimension=384

--- a/step-07/pom.xml
+++ b/step-07/pom.xml
@@ -16,8 +16,9 @@
 
         <compiler-plugin.version>3.13.0</compiler-plugin.version>
 
-        <quarkus.platform.version>3.15.1</quarkus.platform.version>
-        <quarkus-langchain4j.version>0.18.0</quarkus-langchain4j.version>
+        <quarkus.platform.version>3.17.5</quarkus.platform.version>
+        <quarkus-langchain4j.version>0.22.0</quarkus-langchain4j.version>
+        <langchain4j.version>0.36.2</langchain4j.version>
     </properties>
 
     <dependencyManagement>
@@ -35,15 +36,9 @@
     <dependencies>
 
         <dependency>
-            <groupId>io.quarkiverse.langchain4j</groupId>
-            <artifactId>quarkus-langchain4j-openai</artifactId>
-            <version>${quarkus-langchain4j.version}</version>
-        </dependency>
-
-        <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-embeddings-bge-small-en-q</artifactId>
-            <version>0.34.0</version>
+            <version>${langchain4j.version}</version>
         </dependency>
         <dependency>
             <groupId>io.quarkiverse.langchain4j</groupId>
@@ -129,4 +124,38 @@
 
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>openai</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+                <property>
+                    <name>openai</name>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>io.quarkiverse.langchain4j</groupId>
+                    <artifactId>quarkus-langchain4j-openai</artifactId>
+                    <version>${quarkus-langchain4j.version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>ollama</id>
+            <activation>
+                <property>
+                    <name>ollama</name>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>io.quarkiverse.langchain4j</groupId>
+                    <artifactId>quarkus-langchain4j-ollama</artifactId>
+                    <version>${quarkus-langchain4j.version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>

--- a/step-07/src/main/java/dev/langchain4j/quarkus/workshop/BookingRepository.java
+++ b/step-07/src/main/java/dev/langchain4j/quarkus/workshop/BookingRepository.java
@@ -32,16 +32,17 @@ public class BookingRepository implements PanacheRepository<Booking> {
     }
 
     @Tool("List booking for a customer")
+    @Transactional
     public List<Booking> listBookingsForCustomer(String customerFirstName, String customerLastName) {
-        var found = Customer.findByFirstAndLastName(customerFirstName, customerLastName);
-
-        return found
-          .map(customer -> list("customer", customer))
-          .orElseThrow(() -> new CustomerNotFoundException(customerFirstName, customerLastName));
+        var found = Customer.find("firstName = ?1 and lastName = ?2", customerFirstName, customerLastName).singleResultOptional();
+        if (found.isEmpty()) {
+            throw new CustomerNotFoundException(customerFirstName, customerLastName);
+        }
+        return list("customer", found.get());
     }
 
-
     @Tool("Get booking details")
+    @Transactional
     public Booking getBookingDetails(long bookingId, String customerFirstName, String customerLastName) {
         var found = findByIdOptional(bookingId)
           .orElseThrow(() -> new BookingNotFoundException(bookingId));

--- a/step-07/src/main/java/dev/langchain4j/quarkus/workshop/BookingRepository.java
+++ b/step-07/src/main/java/dev/langchain4j/quarkus/workshop/BookingRepository.java
@@ -32,12 +32,12 @@ public class BookingRepository implements PanacheRepository<Booking> {
     }
 
     @Tool("List booking for a customer")
-    public List<Booking> listBookingsForCustomer(String customerName, String customerSurname) {
-        var found = Customer.findByFirstAndLastName(customerName, customerSurname);
+    public List<Booking> listBookingsForCustomer(String customerFirstName, String customerLastName) {
+        var found = Customer.findByFirstAndLastName(customerFirstName, customerLastName);
 
         return found
           .map(customer -> list("customer", customer))
-          .orElseThrow(() -> new CustomerNotFoundException(customerName, customerSurname));
+          .orElseThrow(() -> new CustomerNotFoundException(customerFirstName, customerLastName));
     }
 
 

--- a/step-07/src/main/java/dev/langchain4j/quarkus/workshop/Customer.java
+++ b/step-07/src/main/java/dev/langchain4j/quarkus/workshop/Customer.java
@@ -11,8 +11,4 @@ public class Customer extends PanacheEntity {
 
     String firstName;
     String lastName;
-
-    public static Optional<Customer> findByFirstAndLastName(String firstName, String lastName) {
-        return find("firstName = ?1 and lastName = ?2", firstName, lastName).firstResultOptional();
-    }
 }

--- a/step-07/src/main/java/dev/langchain4j/quarkus/workshop/CustomerSupportAgentWebSocket.java
+++ b/step-07/src/main/java/dev/langchain4j/quarkus/workshop/CustomerSupportAgentWebSocket.java
@@ -3,6 +3,7 @@ package dev.langchain4j.quarkus.workshop;
 import io.quarkus.websockets.next.OnOpen;
 import io.quarkus.websockets.next.OnTextMessage;
 import io.quarkus.websockets.next.WebSocket;
+import jakarta.enterprise.context.control.ActivateRequestContext;
 
 @WebSocket(path = "/customer-support-agent")
 public class CustomerSupportAgentWebSocket {
@@ -19,6 +20,7 @@ public class CustomerSupportAgentWebSocket {
     }
     // --8<-- [start:tools]
     @OnTextMessage
+    @ActivateRequestContext
     public String onTextMessage(String message) {
         return customerSupportAgent.chat(message);
     }

--- a/step-07/src/main/java/dev/langchain4j/quarkus/workshop/CustomerSupportAgentWebSocket.java
+++ b/step-07/src/main/java/dev/langchain4j/quarkus/workshop/CustomerSupportAgentWebSocket.java
@@ -20,7 +20,6 @@ public class CustomerSupportAgentWebSocket {
     }
     // --8<-- [start:tools]
     @OnTextMessage
-    @ActivateRequestContext
     public String onTextMessage(String message) {
         return customerSupportAgent.chat(message);
     }

--- a/step-07/src/main/java/dev/langchain4j/quarkus/workshop/RagRetriever.java
+++ b/step-07/src/main/java/dev/langchain4j/quarkus/workshop/RagRetriever.java
@@ -30,7 +30,7 @@ public class RagRetriever {
                 .contentInjector(new ContentInjector() {
                     @Override
                     public UserMessage inject(List<Content> list, UserMessage userMessage) {
-                        StringBuffer prompt = new StringBuffer(userMessage.singleText());
+                        StringBuilder prompt = new StringBuilder(userMessage.singleText());
                         prompt.append("\nPlease, only use the following information:\n");
                         list.forEach(content -> prompt.append("- ").append(content.textSegment().text()).append("\n"));
                         return new UserMessage(prompt.toString());

--- a/step-07/src/main/resources/application.properties
+++ b/step-07/src/main/resources/application.properties
@@ -1,10 +1,19 @@
+quarkus.langchain4j.log-requests=true
+quarkus.langchain4j.log-responses=true
+
+# OpenAI
 quarkus.langchain4j.openai.api-key=${OPENAI_API_KEY}
 quarkus.langchain4j.openai.chat-model.model-name=gpt-4o
-quarkus.langchain4j.openai.chat-model.log-requests=true
-quarkus.langchain4j.openai.chat-model.log-responses=true
+
 quarkus.langchain4j.openai.chat-model.temperature=1.0
 quarkus.langchain4j.openai.chat-model.max-tokens=1000
 quarkus.langchain4j.openai.chat-model.frequency-penalty=0
+
+# Ollama
+quarkus.langchain4j.ollama.chat-model.model-id=llama3.2
+quarkus.langchain4j.ollama.timeout=180s
+quarkus.langchain4j.ollama.chat-model.temperature=1.0
+
 quarkus.langchain4j.pgvector.dimension=384
 rag.location=src/main/resources/rag
 quarkus.langchain4j.embedding-model.provider=dev.langchain4j.model.embedding.onnx.bgesmallenq.BgeSmallEnQuantizedEmbeddingModel

--- a/step-08/pom.xml
+++ b/step-08/pom.xml
@@ -16,8 +16,9 @@
 
         <compiler-plugin.version>3.13.0</compiler-plugin.version>
 
-        <quarkus.platform.version>3.15.1</quarkus.platform.version>
-        <quarkus-langchain4j.version>0.18.0</quarkus-langchain4j.version>
+        <quarkus.platform.version>3.17.5</quarkus.platform.version>
+        <quarkus-langchain4j.version>0.22.0</quarkus-langchain4j.version>
+        <langchain4j.version>0.36.2</langchain4j.version>
     </properties>
 
     <dependencyManagement>
@@ -35,15 +36,9 @@
     <dependencies>
 
         <dependency>
-            <groupId>io.quarkiverse.langchain4j</groupId>
-            <artifactId>quarkus-langchain4j-openai</artifactId>
-            <version>${quarkus-langchain4j.version}</version>
-        </dependency>
-
-        <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-embeddings-bge-small-en-q</artifactId>
-            <version>0.34.0</version>
+            <version>${langchain4j.version}</version>
         </dependency>
         <dependency>
             <groupId>io.quarkiverse.langchain4j</groupId>
@@ -127,4 +122,38 @@
 
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>openai</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+                <property>
+                    <name>openai</name>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>io.quarkiverse.langchain4j</groupId>
+                    <artifactId>quarkus-langchain4j-openai</artifactId>
+                    <version>${quarkus-langchain4j.version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>ollama</id>
+            <activation>
+                <property>
+                    <name>ollama</name>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>io.quarkiverse.langchain4j</groupId>
+                    <artifactId>quarkus-langchain4j-ollama</artifactId>
+                    <version>${quarkus-langchain4j.version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>

--- a/step-08/src/main/java/dev/langchain4j/quarkus/workshop/BookingRepository.java
+++ b/step-08/src/main/java/dev/langchain4j/quarkus/workshop/BookingRepository.java
@@ -32,10 +32,10 @@ public class BookingRepository implements PanacheRepository<Booking> {
     }
 
     @Tool("List booking for a customer")
-    public List<Booking> listBookingsForCustomer(String customerName, String customerSurname) {
-        var found = Customer.find("firstName = ?1 and lastName = ?2", customerName, customerSurname).singleResultOptional();
+    public List<Booking> listBookingsForCustomer(String customerFirstName, String customerLastName) {
+        var found = Customer.find("firstName = ?1 and lastName = ?2", customerFirstName, customerLastName).singleResultOptional();
         if (found.isEmpty()) {
-            throw new CustomerNotFoundException(customerName, customerSurname);
+            throw new CustomerNotFoundException(customerFirstName, customerLastName);
         }
         return list("customer", found.get());
     }

--- a/step-08/src/main/java/dev/langchain4j/quarkus/workshop/BookingRepository.java
+++ b/step-08/src/main/java/dev/langchain4j/quarkus/workshop/BookingRepository.java
@@ -32,6 +32,7 @@ public class BookingRepository implements PanacheRepository<Booking> {
     }
 
     @Tool("List booking for a customer")
+    @Transactional
     public List<Booking> listBookingsForCustomer(String customerFirstName, String customerLastName) {
         var found = Customer.find("firstName = ?1 and lastName = ?2", customerFirstName, customerLastName).singleResultOptional();
         if (found.isEmpty()) {
@@ -40,8 +41,8 @@ public class BookingRepository implements PanacheRepository<Booking> {
         return list("customer", found.get());
     }
 
-
     @Tool("Get booking details")
+    @Transactional
     public Booking getBookingDetails(long bookingId, String customerFirstName, String customerLastName) {
         Booking found = findById(bookingId);
         if (found == null) {

--- a/step-08/src/main/java/dev/langchain4j/quarkus/workshop/CustomerSupportAgentWebSocket.java
+++ b/step-08/src/main/java/dev/langchain4j/quarkus/workshop/CustomerSupportAgentWebSocket.java
@@ -23,7 +23,6 @@ public class CustomerSupportAgentWebSocket {
     }
 
     @OnTextMessage
-    @ActivateRequestContext
     public String onTextMessage(String message) {
         try {
             return customerSupportAgent.chat(message);

--- a/step-08/src/main/java/dev/langchain4j/quarkus/workshop/CustomerSupportAgentWebSocket.java
+++ b/step-08/src/main/java/dev/langchain4j/quarkus/workshop/CustomerSupportAgentWebSocket.java
@@ -6,6 +6,7 @@ import io.quarkus.websockets.next.OnTextMessage;
 import io.quarkus.websockets.next.WebSocket;
 
 import io.quarkiverse.langchain4j.runtime.aiservice.GuardrailException;
+import jakarta.enterprise.context.control.ActivateRequestContext;
 
 @WebSocket(path = "/customer-support-agent")
 public class CustomerSupportAgentWebSocket {
@@ -22,6 +23,7 @@ public class CustomerSupportAgentWebSocket {
     }
 
     @OnTextMessage
+    @ActivateRequestContext
     public String onTextMessage(String message) {
         try {
             return customerSupportAgent.chat(message);

--- a/step-08/src/main/java/dev/langchain4j/quarkus/workshop/PromptInjectionDetectionService.java
+++ b/step-08/src/main/java/dev/langchain4j/quarkus/workshop/PromptInjectionDetectionService.java
@@ -3,8 +3,10 @@ package dev.langchain4j.quarkus.workshop;
 import dev.langchain4j.service.SystemMessage;
 import dev.langchain4j.service.UserMessage;
 import io.quarkiverse.langchain4j.RegisterAiService;
+import jakarta.enterprise.context.ApplicationScoped;
 
 @RegisterAiService
+@ApplicationScoped
 public interface PromptInjectionDetectionService {
 
     @SystemMessage("""

--- a/step-08/src/main/java/dev/langchain4j/quarkus/workshop/PromptInjectionGuard.java
+++ b/step-08/src/main/java/dev/langchain4j/quarkus/workshop/PromptInjectionGuard.java
@@ -4,15 +4,13 @@ import dev.langchain4j.data.message.UserMessage;
 import io.quarkiverse.langchain4j.guardrails.InputGuardrail;
 import io.quarkiverse.langchain4j.guardrails.InputGuardrailResult;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 
 @ApplicationScoped
 public class PromptInjectionGuard implements InputGuardrail {
 
-    private final PromptInjectionDetectionService service;
-
-    public PromptInjectionGuard(PromptInjectionDetectionService service) {
-        this.service = service;
-    }
+    @Inject
+    PromptInjectionDetectionService service;
 
     @Override
     public InputGuardrailResult validate(UserMessage userMessage) {

--- a/step-08/src/main/java/dev/langchain4j/quarkus/workshop/RagRetriever.java
+++ b/step-08/src/main/java/dev/langchain4j/quarkus/workshop/RagRetriever.java
@@ -30,7 +30,7 @@ public class RagRetriever {
                 .contentInjector(new ContentInjector() {
                     @Override
                     public UserMessage inject(List<Content> list, UserMessage userMessage) {
-                        StringBuffer prompt = new StringBuffer(userMessage.singleText());
+                        StringBuilder prompt = new StringBuilder(userMessage.singleText());
                         prompt.append("\nPlease, only use the following information:\n");
                         list.forEach(content -> prompt.append("- ").append(content.textSegment().text()).append("\n"));
                         return new UserMessage(prompt.toString());

--- a/step-08/src/main/resources/application.properties
+++ b/step-08/src/main/resources/application.properties
@@ -1,10 +1,19 @@
+quarkus.langchain4j.log-requests=true
+quarkus.langchain4j.log-responses=true
+
+# OpenAI
 quarkus.langchain4j.openai.api-key=${OPENAI_API_KEY}
 quarkus.langchain4j.openai.chat-model.model-name=gpt-4o
-quarkus.langchain4j.openai.chat-model.log-requests=true
-quarkus.langchain4j.openai.chat-model.log-responses=true
+
 quarkus.langchain4j.openai.chat-model.temperature=1.0
 quarkus.langchain4j.openai.chat-model.max-tokens=1000
 quarkus.langchain4j.openai.chat-model.frequency-penalty=0
+
+# Ollama
+quarkus.langchain4j.ollama.chat-model.model-id=llama3.2
+quarkus.langchain4j.ollama.timeout=180s
+quarkus.langchain4j.ollama.chat-model.temperature=1.0
+
 quarkus.langchain4j.pgvector.dimension=384
 rag.location=src/main/resources/rag
 quarkus.langchain4j.embedding-model.provider=dev.langchain4j.model.embedding.onnx.bgesmallenq.BgeSmallEnQuantizedEmbeddingModel


### PR DESCRIPTION
I added a maven profile to optionally run all steps using a local ollama server instead of connecting to OpenAI. I believe this could be a good alternative for users not having an OpenAI account. If required the same thing could be done also integrating Jlama for instance. 

If you don't want to change all steps, another option could be adding one more step at the end of the workshop, also showing how to integrate a different server. Let me know which of the 2 possibilities you prefer and I will also update the documentation accordingly.

/cc @kdubois  